### PR TITLE
Feature/let-statment-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pyimpl/src/pyimpl/token/__pycache__/token.cpython-313.pyc
 pyimpl/src/pyimpl/token/__pycache__/tokentype.cpython-313.pyc
 pyimpl/tests/__pycache__/lexer_test.cpython-313-pytest-8.3.3.pyc
 pyimpl/tests/__pycache__/tokentype_test.cpython-313-pytest-8.3.3.pyc
+__pycache__/
 
 #rustimpl ignore list
 rustimpl/target

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ monkey-ide/gradle.properties
 interpreter.iml
 .idea
 
+goimpl/.github/ai-instructions.md
+goimpl/.github/custom-instructions.md

--- a/goimpl/ast/error.go
+++ b/goimpl/ast/error.go
@@ -8,7 +8,12 @@ type Error struct {
 
 func (Error) statmentNode()          {}
 func (e Error) TokenLiteral() string { return e.Message }
-func (e Error) String() string       { return e.Message }
+func (e Error) String() string {
+	if e.Message != "" {
+		return "Error{" + e.Message + "}"
+	}
+	return e.Message
+}
 
 func (e Error) Dump(ident int) string {
 	identation := strings.Repeat("\t", ident)

--- a/goimpl/ast/expression.go
+++ b/goimpl/ast/expression.go
@@ -37,3 +37,22 @@ func (e ExpressionStatement) Dump(ident int) string {
 	out += strings.Repeat("\t", ident-1) + "} //end of ExpressionStatment"
 	return out
 }
+
+// InvalidExpression represents an invalid expression encountered during parsing
+type InvalidExpression struct {
+	Message string // error message describing why the expression is invalid
+}
+
+func (InvalidExpression) expressionNode() {}
+
+func (i InvalidExpression) TokenLiteral() string { return i.Message }
+
+func (i InvalidExpression) String() string { return "invalid expression: " + i.Message }
+
+func (i InvalidExpression) Dump(ident int) string {
+	indentation := strings.Repeat("\t", ident)
+	out := indentation + "ast.InvalidExpression{ //start of InvalidExpression\n"
+	out += indentation + "\tMessage: " + i.Message + "\n"
+	out += indentation + "} //end of InvalidExpression"
+	return out
+}

--- a/goimpl/ast/let.go
+++ b/goimpl/ast/let.go
@@ -16,11 +16,10 @@ func (Let) statmentNode() {}
 func (l Let) TokenLiteral() string { return l.Tok.Literal }
 
 func (l Let) String() string {
-	out := l.Tok.Literal + " " + l.Name.String() + " = "
-	if l.Value != nil {
-		out += l.Value.String()
+	if l.Name != nil && l.Value != nil {
+		return "let " + l.Name.Value + " = " + l.Value.String() + ";"
 	}
-	return out + ";"
+	return "let <incomplete>"
 }
 
 func (l Let) Dump(ident int) string {

--- a/goimpl/parser/internal/errors.go
+++ b/goimpl/parser/internal/errors.go
@@ -1,8 +1,11 @@
 package internal
 
 const (
-	LetErrExpectedIdentifier = "parse let: expected IDENTIFIER, got %s"
-	LetErrExpectedAssign     = "parse let: expected ASSIGN, got %s"
-	LetErrExpectedExpression = "parse let: expected expression, got %s"
-	LetErrExpectedSemicolon  = "parse let: expected semicolon, got %s"
+	LetErrExpectedIdentifier  = "parse let: expected IDENTIFIER, got %s"
+	LetErrExpectedAssign      = "parse let: expected ASSIGN, got %s"
+	LetErrExpectedExpression  = "parse let: expected expression, got %s"
+	LetErrExpectedSemicolon   = "parse let: expected semicolon, got %s"
+	ErrExpectedPrefixParseFn  = "parse expression: expected prefix parse function for token type %s"
+	ErrExpectedIntegerLiteral = "invalid integer literal: %s"
+	ErrExpectedOpenPren       = "parse expression: expected (, got %s"
 )

--- a/goimpl/parser/internal/errors.go
+++ b/goimpl/parser/internal/errors.go
@@ -1,0 +1,8 @@
+package internal
+
+const (
+	LetErrExpectedIdentifier = "parse let: expected IDENTIFIER, got %s"
+	LetErrExpectedAssign     = "parse let: expected ASSIGN, got %s"
+	LetErrExpectedExpression = "parse let: expected expression, got %s"
+	LetErrExpectedSemicolon  = "parse let: expected semicolon, got %s"
+)

--- a/goimpl/parser/let_fixtures_test.go
+++ b/goimpl/parser/let_fixtures_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 type letTestCase struct {
-	tokens   []token.Token
-	wantErr  bool
-	errorMsg string // expected error message when wantErr is true
-	expected string // expected string representation for valid cases
+	tokens            []token.Token
+	expectedErrMsg    string // Non-empty if an error is expected
+	expectedStatement string // Non-empty if a valid statement is expected
 }
 
 var letStatementTests = map[string]letTestCase{
@@ -23,7 +22,7 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.SEMICOLON, Literal: ";"},
 			{Type: token.EOF, Literal: ""},
 		},
-		expected: "let x = 5;",
+		expectedStatement: "let x = 5;",
 	},
 	"missing_identifier": {
 		tokens: []token.Token{
@@ -33,8 +32,7 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.SEMICOLON, Literal: ";"},
 			{Type: token.EOF, Literal: ""},
 		},
-		wantErr:  true,
-		errorMsg: fmt.Sprintf(internal.LetErrExpectedIdentifier, token.ASSIGN),
+		expectedErrMsg: fmt.Sprintf(internal.LetErrExpectedIdentifier, token.ASSIGN),
 	},
 	"missing_assign": {
 		tokens: []token.Token{
@@ -44,8 +42,7 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.SEMICOLON, Literal: ";"},
 			{Type: token.EOF, Literal: ""},
 		},
-		wantErr:  true,
-		errorMsg: fmt.Sprintf(internal.LetErrExpectedAssign, token.INT),
+		expectedErrMsg: fmt.Sprintf(internal.LetErrExpectedAssign, token.INT),
 	},
 	"missing_semicolon": {
 		tokens: []token.Token{
@@ -55,7 +52,6 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.INT, Literal: "5"},
 			{Type: token.EOF, Literal: ""},
 		},
-		wantErr:  true,
-		errorMsg: fmt.Sprintf(internal.LetErrExpectedSemicolon, token.EOF),
+		expectedErrMsg: fmt.Sprintf(internal.LetErrExpectedSemicolon, token.EOF),
 	},
 }

--- a/goimpl/parser/let_fixtures_test.go
+++ b/goimpl/parser/let_fixtures_test.go
@@ -1,0 +1,59 @@
+package parser
+
+import "goimpl/token"
+
+type letTestCase struct {
+	tokens   []token.Token
+	wantErr  bool
+	checkVal bool
+	expected string
+}
+
+var letStatementTests = map[string]letTestCase{
+	"simple_let": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		wantErr:  false,
+		checkVal: true,
+		expected: "let x = 5;",
+	},
+	"missing_identifier": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		wantErr:  true,
+		checkVal: false,
+	},
+	"missing_assign": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		wantErr:  true,
+		checkVal: false,
+	},
+	"missing_semicolon": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.EOF, Literal: ""},
+		},
+		wantErr:  true,
+		checkVal: false,
+	},
+}

--- a/goimpl/parser/let_fixtures_test.go
+++ b/goimpl/parser/let_fixtures_test.go
@@ -54,4 +54,72 @@ var letStatementTests = map[string]letTestCase{
 		},
 		expectedErrMsg: fmt.Sprintf(internal.LetErrExpectedSemicolon, token.EOF),
 	},
+	"missing_value_expression": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedErrMsg: fmt.Sprintf(internal.LetErrExpectedExpression, token.SEMICOLON),
+	},
+	"boolean_literal_true": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.TRUE, Literal: "true"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedStatement: "let x = true;",
+	},
+	"boolean_literal_false": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.FALSE, Literal: "false"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedStatement: "let x = false;",
+	},
+	"prfix_expression_not_five": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.BANG, Literal: "!"},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedStatement: "let x = (!5);",
+	},
+	"prefix_expression_not_y": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.BANG, Literal: "!"},
+			{Type: token.TRUE, Literal: "y"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedStatement: "let x = (!y);",
+	},
+	"prefix_expression_plus_five": {
+		tokens: []token.Token{
+			{Type: token.LET, Literal: "let"},
+			{Type: token.IDENTIFIER, Literal: "x"},
+			{Type: token.ASSIGN, Literal: "="},
+			{Type: token.PLUS, Literal: "+"},
+			{Type: token.INT, Literal: "5"},
+			{Type: token.SEMICOLON, Literal: ";"},
+			{Type: token.EOF, Literal: ""},
+		},
+		expectedStatement: "let x = (+5);",
+	},
 }

--- a/goimpl/parser/let_fixtures_test.go
+++ b/goimpl/parser/let_fixtures_test.go
@@ -1,12 +1,16 @@
 package parser
 
-import "goimpl/token"
+import (
+	"fmt"
+	"goimpl/parser/internal"
+	"goimpl/token"
+)
 
 type letTestCase struct {
 	tokens   []token.Token
 	wantErr  bool
-	checkVal bool
-	expected string
+	errorMsg string // expected error message when wantErr is true
+	expected string // expected string representation for valid cases
 }
 
 var letStatementTests = map[string]letTestCase{
@@ -19,8 +23,6 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.SEMICOLON, Literal: ";"},
 			{Type: token.EOF, Literal: ""},
 		},
-		wantErr:  false,
-		checkVal: true,
 		expected: "let x = 5;",
 	},
 	"missing_identifier": {
@@ -32,7 +34,7 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.EOF, Literal: ""},
 		},
 		wantErr:  true,
-		checkVal: false,
+		errorMsg: fmt.Sprintf(internal.LetErrExpectedIdentifier, token.ASSIGN),
 	},
 	"missing_assign": {
 		tokens: []token.Token{
@@ -43,7 +45,7 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.EOF, Literal: ""},
 		},
 		wantErr:  true,
-		checkVal: false,
+		errorMsg: fmt.Sprintf(internal.LetErrExpectedAssign, token.INT),
 	},
 	"missing_semicolon": {
 		tokens: []token.Token{
@@ -54,6 +56,6 @@ var letStatementTests = map[string]letTestCase{
 			{Type: token.EOF, Literal: ""},
 		},
 		wantErr:  true,
-		checkVal: false,
+		errorMsg: fmt.Sprintf(internal.LetErrExpectedSemicolon, token.EOF),
 	},
 }

--- a/goimpl/parser/let_test.go
+++ b/goimpl/parser/let_test.go
@@ -1,0 +1,69 @@
+package parser
+
+import (
+	"goimpl/ast"
+	"goimpl/lexer"
+	"goimpl/parser/pratt"
+	"testing"
+	"time"
+)
+
+// FIXME: review bellow test and checks once you update statment.go parseLetStatement
+func TestLet(t *testing.T) {
+	for name, fix := range letStatementTests {
+		t.Run(name, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+
+				lex := lexer.NewStubLexer(fix.tokens)
+				var p ParserType = pratt.New(&lex)
+				prog, ok := p.ParseProgram()
+
+				if fix.wantErr {
+					if ok {
+						t.Error("expected parser errors but got none")
+					}
+					return
+				}
+
+				if !ok {
+					t.Error("parser had errors")
+					return
+				}
+
+				if len(prog.Statements) != 1 {
+					t.Errorf("program has wrong number of statements. got=%d", len(prog.Statements))
+					return
+				}
+
+				stmt, ok := prog.Statements[0].(*ast.Let)
+				if !ok {
+					t.Errorf("program.Statements[0] is not *ast.Let. got=%T", prog.Statements[0])
+					return
+				}
+
+				if fix.checkVal {
+					if stmt.Name == nil || stmt.Name.Value != "x" {
+						t.Errorf("let statement name not 'x'. got=%v", stmt.Name)
+					}
+
+					if stmt.Value == nil {
+						t.Error("let statement value is nil")
+					}
+
+					if fix.expected != "" && stmt.String() != fix.expected {
+						t.Errorf("wrong statement string. got=%q, want=%q", stmt.String(), fix.expected)
+					}
+				}
+			}()
+
+			select {
+			case <-done:
+				return
+			case <-time.After(500 * time.Millisecond):
+				t.Error("test exceeded timeout of 500ms")
+			}
+		})
+	}
+}

--- a/goimpl/parser/parser.go
+++ b/goimpl/parser/parser.go
@@ -4,9 +4,8 @@ import "goimpl/ast"
 
 // ParserType defines the core functionality of a parser implementation.
 // Any parser implementation must be able to parse a complete program and
-// indicate whether parsing was successful.
+// indicate whether parsing was successful or return ast.Error.
 type ParserType interface {
-	// ParseProgram parses a complete program and returns the AST along with a success flag.
-	// The boolean return indicates if parsing completed without errors.
-	ParseProgram() (ast.Program, bool)
+	// ParseProgram parses a complete program and returns the AST or ast.Error.
+	ParseProgram() ast.Program
 }

--- a/goimpl/parser/pratt/expression.go
+++ b/goimpl/parser/pratt/expression.go
@@ -1,7 +1,6 @@
 package pratt
 
 import (
-	"fmt"
 	"goimpl/ast"
 	"goimpl/parser/internal"
 	"goimpl/token"
@@ -12,8 +11,8 @@ import (
 func (p *Parser) parseExpression(precedence internal.Precidence) ast.Expression {
 	prefix := p.prefixParseFns[p.currTok.Type]
 	if prefix == nil {
-		msg := fmt.Sprintf("no prefix parse function for %s found", p.currTok.Type)
-		p.errors = append(p.errors, msg)
+		// FIXME: need to return as.Error
+		//fmt.Sprintf("no prefix parse function for %s found", p.currTok.Type)
 		return nil
 	}
 
@@ -73,8 +72,8 @@ var (
 			literal.Value = value
 			return literal
 		}
-		msg := "could not parse " + parser.currTok.Literal + " as integer"
-		parser.errors = append(parser.errors, msg)
+		//FIXME: need to return as.Error
+		//"could not parse " + parser.currTok.Literal + " as integer"
 		return nil
 	}
 
@@ -93,8 +92,8 @@ var (
 		expr := parser.parseExpression(internal.LOWEST)
 
 		if parser.peekTok.Type != token.RPRAN {
-			msg := "expected )"
-			parser.errors = append(parser.errors, msg)
+			//FIXME: need to return as.Error
+			// "expected )"
 			return nil
 		}
 

--- a/goimpl/parser/pratt/expression.go
+++ b/goimpl/parser/pratt/expression.go
@@ -1,6 +1,7 @@
 package pratt
 
 import (
+	"fmt"
 	"goimpl/ast"
 	"goimpl/parser/internal"
 	"goimpl/token"
@@ -11,9 +12,9 @@ import (
 func (p *Parser) parseExpression(precedence internal.Precidence) ast.Expression {
 	prefix := p.prefixParseFns[p.currTok.Type]
 	if prefix == nil {
-		// FIXME: need to return as.Error
-		//fmt.Sprintf("no prefix parse function for %s found", p.currTok.Type)
-		return nil
+		return &ast.InvalidExpression{
+			Message: fmt.Sprintf(internal.ErrExpectedPrefixParseFn, p.currTok.Type),
+		}
 	}
 
 	leftExpr := prefix(p)
@@ -72,9 +73,9 @@ var (
 			literal.Value = value
 			return literal
 		}
-		//FIXME: need to return as.Error
-		//"could not parse " + parser.currTok.Literal + " as integer"
-		return nil
+		return &ast.InvalidExpression{
+			Message: fmt.Sprintf(internal.ErrExpectedIntegerLiteral, parser.currTok.Literal),
+		}
 	}
 
 	// parseBooleanExpr handles true/false literals.
@@ -92,9 +93,9 @@ var (
 		expr := parser.parseExpression(internal.LOWEST)
 
 		if parser.peekTok.Type != token.RPRAN {
-			//FIXME: need to return as.Error
-			// "expected )"
-			return nil
+			return &ast.InvalidExpression{
+				Message: fmt.Sprintf(internal.ErrExpectedOpenPren, parser.peekTok.Type),
+			}
 		}
 
 		parser.nextToken() // consume the ')'

--- a/goimpl/parser/pratt/parser.go
+++ b/goimpl/parser/pratt/parser.go
@@ -30,6 +30,7 @@ func New(l lexer.Lexer) *Parser {
 		token.INT:        parseIntegerLiteral,
 		token.BANG:       parsePrefixExpr,
 		token.MINUS:      parsePrefixExpr,
+		token.PLUS:       parsePrefixExpr,
 		token.TRUE:       parseBooleanExpr,
 		token.FALSE:      parseBooleanExpr,
 		token.LPRAN:      parseGroupedExpression,

--- a/goimpl/parser/pratt/statement.go
+++ b/goimpl/parser/pratt/statement.go
@@ -21,12 +21,12 @@ func (p *Parser) parseStatement() ast.Statement {
 
 // parseLetStatement parses a let statement in the form: let <identifier> = <expression>;
 func (p *Parser) parseLetStatement() ast.Statement {
+	errStmt := &ast.Error{}
 	stmt := &ast.Let{Tok: p.currTok}
 
 	if p.peekTok.Type != token.IDENTIFIER {
-		msg := fmt.Sprintf("expected IDENTIFIER, got %s", p.peekTok.Type)
-		p.errors = append(p.errors, msg)
-		return nil
+		errStmt.Message = fmt.Sprintf(internal.LetErrExpectedIdentifier, p.peekTok.Type)
+		return errStmt
 	}
 
 	p.nextToken()
@@ -36,9 +36,8 @@ func (p *Parser) parseLetStatement() ast.Statement {
 	}
 
 	if p.peekTok.Type != token.ASSIGN {
-		msg := fmt.Sprintf("expected ASSIGN, got %s", p.peekTok.Type)
-		p.errors = append(p.errors, msg)
-		return nil
+		errStmt.Message = fmt.Sprintf(internal.LetErrExpectedAssign, p.peekTok.Type)
+		return errStmt
 	}
 
 	p.nextToken() // consume the ASSIGN token
@@ -47,10 +46,9 @@ func (p *Parser) parseLetStatement() ast.Statement {
 	if expr := p.parseExpression(internal.LOWEST); expr != nil {
 		stmt.Value = expr
 	} else {
-		return nil
+		errStmt.Message = fmt.Sprintf(internal.LetErrExpectedExpression, p.currTok.Type)
+		return errStmt
 	}
-
-	// FIXME: look at bellow , I need to return ast.Error instead when parsing fails
 
 	// Advance until we find a semicolon or EOF
 	for p.currTok.Type != token.SEMICOLON && p.currTok.Type != token.EOF {
@@ -58,9 +56,8 @@ func (p *Parser) parseLetStatement() ast.Statement {
 	}
 
 	if p.currTok.Type == token.EOF {
-		msg := fmt.Sprintf("expected semicolon, got EOF")
-		p.errors = append(p.errors, msg)
-		return nil
+		errStmt.Message = fmt.Sprintf(internal.LetErrExpectedSemicolon, token.EOF)
+		return errStmt
 	}
 
 	return stmt
@@ -92,6 +89,9 @@ func (p *Parser) parseExpressionStatement() ast.Statement {
 		}
 	}
 
-	p.errors = append(p.errors, "could not parse expression statement")
-	return nil
+	return &ast.Error{
+		//FIXME: add error message
+		// Message: fmt.Sprintf(internal.ExprErrExpectedSemicolon, p.peekTok.Type),
+	}
+
 }

--- a/goimpl/parser/pratt/statement.go
+++ b/goimpl/parser/pratt/statement.go
@@ -50,8 +50,17 @@ func (p *Parser) parseLetStatement() ast.Statement {
 		return nil
 	}
 
-	for p.currTok.Type != token.SEMICOLON {
+	// FIXME: look at bellow , I need to return ast.Error instead when parsing fails
+
+	// Advance until we find a semicolon or EOF
+	for p.currTok.Type != token.SEMICOLON && p.currTok.Type != token.EOF {
 		p.nextToken()
+	}
+
+	if p.currTok.Type == token.EOF {
+		msg := fmt.Sprintf("expected semicolon, got EOF")
+		p.errors = append(p.errors, msg)
+		return nil
 	}
 
 	return stmt

--- a/goimpl/token/token.go
+++ b/goimpl/token/token.go
@@ -1,17 +1,14 @@
 package token
 
+import "slices"
+
 type Token struct {
 	Type    TokenType
 	Literal string
 }
 
 func (t Token) isOneOf(types ...TokenType) bool {
-	for _, typ := range types {
-		if t.Type == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(types, t.Type)
 }
 
 func (t Token) String() string {
@@ -63,3 +60,56 @@ const (
 	TRUE     TokenType = "TRUE"
 	FALSE    TokenType = "FALSE"
 )
+
+func Lookup(ident string) Token {
+	switch ident {
+	case "+":
+		return Token{Type: PLUS, Literal: ident}
+	case "-":
+		return Token{Type: MINUS, Literal: ident}
+	case "*":
+		return Token{Type: ASTER, Literal: ident}
+	case "/":
+		return Token{Type: SLASH, Literal: ident}
+	case "<":
+		return Token{Type: LT, Literal: ident}
+	case ">":
+		return Token{Type: GT, Literal: ident}
+	case "==":
+		return Token{Type: EQ, Literal: ident}
+	case "!=":
+		return Token{Type: NEQ, Literal: ident}
+	case "=":
+		return Token{Type: ASSIGN, Literal: ident}
+	case ",":
+		return Token{Type: COMMA, Literal: ident}
+	case ";":
+		return Token{Type: SEMICOLON, Literal: ident}
+	case "(":
+		return Token{Type: LPRAN, Literal: ident}
+	case ")":
+		return Token{Type: RPRAN, Literal: ident}
+	case "{":
+		return Token{Type: LBRACE, Literal: ident}
+	case "}":
+		return Token{Type: RBRACE, Literal: ident}
+	case "!":
+		return Token{Type: BANG, Literal: ident}
+	case "fn":
+		return Token{Type: FUNCTION, Literal: ident}
+	case "let":
+		return Token{Type: LET, Literal: ident}
+	case "return":
+		return Token{Type: RETURN, Literal: ident}
+	case "if":
+		return Token{Type: IF, Literal: ident}
+	case "else":
+		return Token{Type: ELSE, Literal: ident}
+	case "true":
+		return Token{Type: TRUE, Literal: ident}
+	case "false":
+		return Token{Type: FALSE, Literal: ident}
+	default:
+		return Token{Type: IDENTIFIER, Literal: ident}
+	}
+}


### PR DESCRIPTION
- let x = ; // missing expression
- let x = true;
- let x = !5; //prefix expression
- let x = !y;
- let x = -5

changes:
- added InvalidExpression type , will return that instead of nil
- started refactoring code to use InvalidExpression.
- added lookup to tken package taking token as string and returning Token type

gitignore:
- minor update to ignore compiled python code __pycache__